### PR TITLE
[Bug] Allow only approval for URI auth sessions AT-838

### DIFF
--- a/FuturaeSampleApp/Features/Authentication/AuthApprovalView.swift
+++ b/FuturaeSampleApp/Features/Authentication/AuthApprovalView.swift
@@ -131,7 +131,7 @@ struct AuthApprovalView: View {
                 RoundedButton(title: String.approve, icon: ImageAsset.approve, action: { viewModel.replyAuth(.approve) }, style: .success, isFullWidth: true)
                 
                 switch viewModel.authType {
-                case .offlineQR:
+                case .offlineQR, .url:
                     EmptyView()
                 default:
                     HStack(spacing: 16) {


### PR DESCRIPTION
### Changelog

- Update `AuthApprovalView` to only expose "Approve" operation for URI auth sessions