### PR TITLE
[Bug] register APNs token with SDK as soon as it's launched

### DIFF
--- a/FuturaeSampleApp/AppDelegate.swift
+++ b/FuturaeSampleApp/AppDelegate.swift
@@ -12,6 +12,8 @@ import FuturaeKit
 import SwiftUI
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    private(set) var pendingDeviceToken: Data?
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
@@ -19,8 +21,13 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         setupNotificationCenter(application)
         setupNavigationBarAppearance()
         setupTabBarAppearance()
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(onSDKDidLaunch), name: .sdkDidLaunch, object: nil)
+
         return true
+    }
+
+    @objc private func onSDKDidLaunch() {
+        registerPendingPushTokenIfNeeded()
     }
 }
 
@@ -88,8 +95,21 @@ extension AppDelegate {
         _ application: UIApplication,
         didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
     ) {
-        guard FuturaeService.client.sdkIsLaunched else { return }
-        
+        guard FuturaeService.client.sdkIsLaunched else {
+            pendingDeviceToken = deviceToken
+            return
+        }
+
+        registerPushToken(deviceToken)
+    }
+
+    private func registerPendingPushTokenIfNeeded() {
+        guard let token = pendingDeviceToken else { return }
+        pendingDeviceToken = nil
+        registerPushToken(token)
+    }
+
+    private func registerPushToken(_ deviceToken: Data) {
         Task {
             do {
                 try await FuturaeService.client.registerPushToken(deviceToken).execute()

--- a/FuturaeSampleApp/Common/Notifications.swift
+++ b/FuturaeSampleApp/Common/Notifications.swift
@@ -12,4 +12,5 @@ extension Notification.Name {
     static let accountsChanged = Notification.Name("accountsChanged")
     static let authenticationProcessed = Notification.Name("authenticationProcessed")
     static let qrTabRequested = Notification.Name("qrTabRequested")
+    static let sdkDidLaunch = Notification.Name("sdkDidLaunch")
 }

--- a/FuturaeSampleApp/Features/Configuration/SDKConfigurationViewModel.swift
+++ b/FuturaeSampleApp/Features/Configuration/SDKConfigurationViewModel.swift
@@ -30,6 +30,7 @@ final class SDKConfigurationViewModel: ObservableObject {
         do {
             FuturaeService.client.enableLogging()
             try FuturaeService.client.launch(config: config)
+            NotificationCenter.default.post(name: .sdkDidLaunch, object: nil)
             prefs.save(sdkConfigData: sdkConfigData, userDefaults: sdkConfigData.savePrefs)
             prefs.saveBool(.launchSDK, value: true, userDefaults: sdkConfigData.saveLaunch)
         } catch {

--- a/FuturaeSampleApp/Features/Tabs/MainTabView.swift
+++ b/FuturaeSampleApp/Features/Tabs/MainTabView.swift
@@ -18,6 +18,7 @@ struct MainTabView: View {
             if !FuturaeService.client.sdkIsLaunched {
                 FuturaeService.client.enableLogging()
                 try FuturaeService.client.launch(config: GlobalPreferences.shared.sdkConfigData.ftrConfig)
+                NotificationCenter.default.post(name: .sdkDidLaunch, object: nil)
             }
         } catch {
             self._error = .init(initialValue: error)


### PR DESCRIPTION
### Changelog
- Add `Notifications.sdkDidLaunch` to trigger a flow that registers the APNs token with SDK as soon as its launched
- Fixes cases where the App would not receive Push notifications on the first App launch