### PR TITLE
[Bug] Refresh accounts after unenrolling account via Push Notification

### DIFF
--- a/FuturaeSampleApp/AppDelegate.swift
+++ b/FuturaeSampleApp/AppDelegate.swift
@@ -187,6 +187,7 @@ extension AppDelegate {
             }
             
             try? FuturaeService.client.deleteAccount(account)
+            NotificationCenter.default.post(name: .accountsChanged,object: nil)
         case .arbitraryNotification:
             break
         default:


### PR DESCRIPTION
### Changelog

- Update sample to refresh accounts upon unenrolling account via PN